### PR TITLE
Remove @RestrictTo in favor of just @InternalMavericksApi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## Version 2.1.0
+- Removed `@RestrictTo` annotations in favor of just `@InternalMavericksApi`. The Kotlin opt-in annotations work more reliably than the Android lint rules and there is no need for both.
+
 ## Version 2.0.0
 Mavericks 2.0 is a ground up rewrite for coroutines. Check out the [documentation for 2.0](https://airbnb.io/mavericks/#/new-2x) to find out what is new and how to upgrade.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.0.0
+VERSION_NAME=2.1.0-SNAPSHOT
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Mavericks is an Android application framework that makes product development fast and fun.
 POM_URL=https://github.com/airbnb/mavericks

--- a/mvrx-mocking/src/main/kotlin/com/airbnb/mvrx/mocking/MockBuilder.kt
+++ b/mvrx-mocking/src/main/kotlin/com/airbnb/mvrx/mocking/MockBuilder.kt
@@ -4,7 +4,6 @@ package com.airbnb.mvrx.mocking
 
 import android.os.Parcelable
 import android.util.Log
-import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.InternalMavericksApi
@@ -1480,7 +1479,6 @@ open class MavericksViewMocks<V : MockableMavericksView, Args : Parcelable> @Pub
          * Exposed for internal tests to allow us to workaround the requirement that this class
          * can only be created via [getFrom].
          */
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @InternalMavericksApi
         fun <R> allowCreationForTesting(block: () -> R): R {
             allowCreationForTesting = true

--- a/mvrx-mocking/src/main/kotlin/com/airbnb/mvrx/mocking/SynchronousMavericksStateStore.kt
+++ b/mvrx-mocking/src/main/kotlin/com/airbnb/mvrx/mocking/SynchronousMavericksStateStore.kt
@@ -1,6 +1,5 @@
 package com.airbnb.mvrx.mocking
 
-import androidx.annotation.RestrictTo
 import com.airbnb.mvrx.InternalMavericksApi
 import com.airbnb.mvrx.MavericksStateStore
 import kotlinx.coroutines.channels.BufferOverflow
@@ -14,7 +13,6 @@ import kotlinx.coroutines.flow.distinctUntilChanged
  * The intention of this is to allow state changes in tests to be tracked
  * synchronously.
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @InternalMavericksApi
 class SynchronousMavericksStateStore<S : Any>(initialState: S) : MavericksStateStore<S> {
 

--- a/mvrx-navigation/src/main/kotlin/com/airbnb/mvrx/navigation/navigationLifecycleAwareLazy.kt
+++ b/mvrx-navigation/src/main/kotlin/com/airbnb/mvrx/navigation/navigationLifecycleAwareLazy.kt
@@ -2,9 +2,9 @@
 
 package com.airbnb.mvrx.navigation
 
-import androidx.annotation.RestrictTo
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import com.airbnb.mvrx.InternalMavericksApi
 import java.io.Serializable
 
 private object UninitializedValue
@@ -12,7 +12,7 @@ private object UninitializedValue
 /**
  * This was copied from SynchronizedLazyImpl but modified to automatically initialize in ON_CREATE.
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY)
+@InternalMavericksApi
 @SuppressWarnings("Detekt.ClassNaming")
 class navigationLifecycleAwareLazy<out T>(
     owner: LifecycleOwner,

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/Async.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/Async.kt
@@ -1,7 +1,5 @@
 package com.airbnb.mvrx
 
-import androidx.annotation.RestrictTo
-
 /**
  * The T generic is unused for some classes but since it is sealed and useful for Success and Fail,
  * it should be on all of them.
@@ -58,7 +56,6 @@ data class Success<out T>(private val value: T) : Async<T>(complete = true, shou
      * @see Async.setMetadata
      * @see Async.getMetadata
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @InternalMavericksApi
     var metadata: Any? = null
 }

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksExtensions.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksExtensions.kt
@@ -2,7 +2,6 @@ package com.airbnb.mvrx
 
 import android.os.Bundle
 import android.os.Parcelable
-import androidx.annotation.RestrictTo
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import java.io.Serializable
@@ -16,7 +15,6 @@ import kotlin.reflect.KProperty
  * Looks for [Mavericks.KEY_ARG] on the arguments of the fragments.
  */
 @Suppress("FunctionName")
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @InternalMavericksApi
 fun <T : Fragment> T._fragmentArgsProvider(): Any? = arguments?.get(Mavericks.KEY_ARG)
 

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksFactory.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksFactory.kt
@@ -1,6 +1,5 @@
 package com.airbnb.mvrx
 
-import androidx.annotation.RestrictTo
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 
@@ -83,7 +82,6 @@ private fun <VM : MavericksViewModel<S>, S : MavericksState> createDefaultViewMo
     return null
 }
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @InternalMavericksApi
 open class ViewModelDoesNotExistException(message: String) : IllegalStateException(message) {
     constructor(

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksStateFactory.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksStateFactory.kt
@@ -1,10 +1,8 @@
 package com.airbnb.mvrx
 
 import android.os.Build
-import androidx.annotation.RestrictTo
 import java.lang.reflect.Modifier
 
-@RestrictTo(RestrictTo.Scope.LIBRARY)
 @InternalMavericksApi
 interface MavericksStateFactory<VM : MavericksViewModel<S>, S : MavericksState> {
 
@@ -16,7 +14,6 @@ interface MavericksStateFactory<VM : MavericksViewModel<S>, S : MavericksState> 
     ): S
 }
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @InternalMavericksApi
 class RealMavericksStateFactory<VM : MavericksViewModel<S>, S : MavericksState> : MavericksStateFactory<VM, S> {
 

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksStateStore.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksStateStore.kt
@@ -1,9 +1,7 @@
 package com.airbnb.mvrx
 
-import androidx.annotation.RestrictTo
 import kotlinx.coroutines.flow.Flow
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @InternalMavericksApi
 interface MavericksStateStore<S : Any> {
     val state: S

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksTestOverrides.java
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksTestOverrides.java
@@ -3,7 +3,6 @@ package com.airbnb.mvrx;
 
 import androidx.annotation.RestrictTo;
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @InternalMavericksApi
 public class MavericksTestOverrides {
     /**

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModel.kt
@@ -1,7 +1,6 @@
 package com.airbnb.mvrx
 
 import androidx.annotation.CallSuper
-import androidx.annotation.RestrictTo
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
@@ -47,7 +46,6 @@ abstract class MavericksViewModel<S : MavericksState>(
     private val configFactory = Mavericks.viewModelConfigFactory
 
     @Suppress("LeakingThis")
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @InternalMavericksApi
     val config: MavericksViewModelConfig<S> = configFactory.provideConfig(
         this,

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelConfig.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelConfig.kt
@@ -1,6 +1,5 @@
 package com.airbnb.mvrx
 
-import androidx.annotation.RestrictTo
 import kotlinx.coroutines.CoroutineScope
 
 /**
@@ -16,7 +15,7 @@ abstract class MavericksViewModelConfig<S : Any>(
      * The state store instance that will control the state of the ViewModel.
      */
     @InternalMavericksApi
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) val stateStore: MavericksStateStore<S>,
+    val stateStore: MavericksStateStore<S>,
     /**
      * The coroutine scope that will be provided to the view model.
      */

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelExtensions.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelExtensions.kt
@@ -2,17 +2,11 @@
 
 package com.airbnb.mvrx
 
-import androidx.annotation.RestrictTo
 import androidx.lifecycle.LifecycleOwner
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlin.reflect.KProperty1
 
-/**
- * This name is obfuscated because @RestrictTo doesn't actually work. It would be named onEach.
- * https://issuetracker.google.com/issues/168357308
- */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @InternalMavericksApi
 fun <VM : MavericksViewModel<S>, S : MavericksState> VM._internal(
     owner: LifecycleOwner?,
@@ -20,11 +14,6 @@ fun <VM : MavericksViewModel<S>, S : MavericksState> VM._internal(
     action: suspend (S) -> Unit
 ) = stateFlow.resolveSubscription(owner, deliveryMode, action)
 
-/**
- * This name is obfuscated because @RestrictTo doesn't actually work. It would be named onEach.
- * https://issuetracker.google.com/issues/168357308
- */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @InternalMavericksApi
 fun <VM : MavericksViewModel<S>, S : MavericksState, A> VM._internal1(
     owner: LifecycleOwner?,
@@ -38,11 +27,6 @@ fun <VM : MavericksViewModel<S>, S : MavericksState, A> VM._internal1(
         action(a)
     }
 
-/**
- * This name is obfuscated because @RestrictTo doesn't actually work. It would be named onEach.
- * https://issuetracker.google.com/issues/168357308
- */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @InternalMavericksApi
 fun <VM : MavericksViewModel<S>, S : MavericksState, A, B> VM._internal2(
     owner: LifecycleOwner?,
@@ -57,11 +41,6 @@ fun <VM : MavericksViewModel<S>, S : MavericksState, A, B> VM._internal2(
         action(a, b)
     }
 
-/**
- * This name is obfuscated because @RestrictTo doesn't actually work. It would be named onEach.
- * https://issuetracker.google.com/issues/168357308
- */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @InternalMavericksApi
 fun <VM : MavericksViewModel<S>, S : MavericksState, A, B, C> VM._internal3(
     owner: LifecycleOwner?,
@@ -77,11 +56,6 @@ fun <VM : MavericksViewModel<S>, S : MavericksState, A, B, C> VM._internal3(
         action(a, b, c)
     }
 
-/**
- * This name is obfuscated because @RestrictTo doesn't actually work. It would be named onEach.
- * https://issuetracker.google.com/issues/168357308
- */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @InternalMavericksApi
 fun <VM : MavericksViewModel<S>, S : MavericksState, A, B, C, D> VM._internal4(
     owner: LifecycleOwner?,
@@ -98,11 +72,6 @@ fun <VM : MavericksViewModel<S>, S : MavericksState, A, B, C, D> VM._internal4(
         action(a, b, c, d)
     }
 
-/**
- * This name is obfuscated because @RestrictTo doesn't actually work. It would be named onEach.
- * https://issuetracker.google.com/issues/168357308
- */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @InternalMavericksApi
 fun <VM : MavericksViewModel<S>, S : MavericksState, A, B, C, D, E> VM._internal5(
     owner: LifecycleOwner?,
@@ -120,11 +89,6 @@ fun <VM : MavericksViewModel<S>, S : MavericksState, A, B, C, D, E> VM._internal
         action(a, b, c, d, e)
     }
 
-/**
- * This name is obfuscated because @RestrictTo doesn't actually work. It would be named onEach.
- * https://issuetracker.google.com/issues/168357308
- */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @InternalMavericksApi
 fun <VM : MavericksViewModel<S>, S : MavericksState, A, B, C, D, E, F> VM._internal6(
     owner: LifecycleOwner?,
@@ -143,11 +107,6 @@ fun <VM : MavericksViewModel<S>, S : MavericksState, A, B, C, D, E, F> VM._inter
         action(a, b, c, d, e, f)
     }
 
-/**
- * This name is obfuscated because @RestrictTo doesn't actually work. It would be named onEach.
- * https://issuetracker.google.com/issues/168357308
- */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @InternalMavericksApi
 fun <VM : MavericksViewModel<S>, S : MavericksState, A, B, C, D, E, F, G> VM._internal7(
     owner: LifecycleOwner?,
@@ -167,11 +126,6 @@ fun <VM : MavericksViewModel<S>, S : MavericksState, A, B, C, D, E, F, G> VM._in
         action(a, b, c, d, e, f, g)
     }
 
-/**
- * This name is obfuscated because @RestrictTo doesn't actually work. It would be named onAsync.
- * https://issuetracker.google.com/issues/168357308
- */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @InternalMavericksApi
 fun <VM : MavericksViewModel<S>, S : MavericksState, T> VM._internalSF(
     owner: LifecycleOwner?,

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelProvider.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelProvider.kt
@@ -2,7 +2,6 @@ package com.airbnb.mvrx
 
 import android.os.Bundle
 import android.os.Parcelable
-import androidx.annotation.RestrictTo
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModelProvider
@@ -12,7 +11,6 @@ import java.io.Serializable
  * Helper ViewModelProvider that has a single method for taking either a [Fragment] or [FragmentActivity] instead
  * of two separate ones. The logic for providing the correct scope is inside the method.
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY)
 @InternalMavericksApi
 object MavericksViewModelProvider {
     /**

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/lifecycleAwareLazy.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/lifecycleAwareLazy.kt
@@ -2,7 +2,6 @@
 
 package com.airbnb.mvrx
 
-import androidx.annotation.RestrictTo
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import java.io.Serializable
@@ -12,7 +11,6 @@ private object UninitializedValue
 /**
  * This was copied from SynchronizedLazyImpl but modified to automatically initialize in ON_CREATE.
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @InternalMavericksApi
 @SuppressWarnings("Detekt.ClassNaming")
 class lifecycleAwareLazy<out T>(private val owner: LifecycleOwner, initializer: () -> T) : Lazy<T>,

--- a/testing/src/main/kotlin/com/airbnb/mvrx/MvRxTestOverridesProxy.java
+++ b/testing/src/main/kotlin/com/airbnb/mvrx/MvRxTestOverridesProxy.java
@@ -8,7 +8,6 @@ import com.airbnb.mvrx.test.MvRxTestRule;
  * Used as a proxy between {@link MvRxTestRule} and MvRx.
  * this is Java because the flag is package private.
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY)
 @InternalMavericksApi
 public class MvRxTestOverridesProxy {
 


### PR DESCRIPTION
The Kotlin opt-in annotations work more reliably than the Android lint rules and there is no need for both.

This is necessary because when I upgraded to AGP 7 for Compose, it broke a bunch of `@RestrictTo` calls across Mavericks libraries that were marked as LIBRARY_GROUP and are in the same library group but fail lint (but don't show up as errors in Android Studio). The entire RestrictTo feature has been continually broken in some way while `@InternalMavericksApi` has been working reliably so let's just stick to it.

I left one `@RestrictTo` in `BaseMvRxViewModel` for legacy reasons. It has some valid use cases for external users so we never added `@InternalMavericksApi` and I'm leaving it untouched.