### PR TITLE
Fix lifecycle 2.3.0 throwing IllegalStateException when using `MavericksLauncherActivity`

### DIFF
--- a/hellodagger/build.gradle
+++ b/hellodagger/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     implementation Libraries.viewModelKtx
     implementation Libraries.multidex
     implementation project(":mvrx")
+    implementation project(":mvrx-mocking")
+    implementation project(":launcher")
 
     debugImplementation Libraries.fragmentTesting
 

--- a/hellodagger/src/main/java/com/airbnb/mvrx/hellodagger/HelloDaggerApplication.kt
+++ b/hellodagger/src/main/java/com/airbnb/mvrx/hellodagger/HelloDaggerApplication.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import com.airbnb.mvrx.Mavericks
 import com.airbnb.mvrx.hellodagger.di.AppComponent
 import com.airbnb.mvrx.hellodagger.di.DaggerAppComponent
+import com.airbnb.mvrx.mocking.MockableMavericks
 
 class HelloDaggerApplication : Application() {
 
@@ -13,10 +14,11 @@ class HelloDaggerApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         appComponent = DaggerAppComponent.create()
-        Mavericks.initialize(this)
+        MockableMavericks.initialize(this)
     }
 }
 
 fun ComponentActivity.appComponent(): AppComponent {
     return (application as HelloDaggerApplication).appComponent
 }
+

--- a/hellodagger/src/main/java/com/airbnb/mvrx/hellodagger/HelloFragment.kt
+++ b/hellodagger/src/main/java/com/airbnb/mvrx/hellodagger/HelloFragment.kt
@@ -1,6 +1,7 @@
 package com.airbnb.mvrx.hellodagger
 
 import android.os.Bundle
+import android.os.Parcelable
 import android.view.View
 import androidx.fragment.app.Fragment
 import com.airbnb.mvrx.Fail
@@ -9,11 +10,14 @@ import com.airbnb.mvrx.MavericksView
 import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.fragmentViewModel
+import com.airbnb.mvrx.mocking.MavericksViewMocks
+import com.airbnb.mvrx.mocking.MockableMavericksView
+import com.airbnb.mvrx.mocking.mockSingleViewModel
 import com.airbnb.mvrx.withState
 import kotlinx.android.synthetic.main.fragment_hello.helloButton
 import kotlinx.android.synthetic.main.fragment_hello.messageTextView
 
-class HelloFragment : Fragment(R.layout.fragment_hello), MavericksView {
+class HelloFragment : Fragment(R.layout.fragment_hello), MockableMavericksView {
 
     val viewModel: HelloDaggerViewModel by fragmentViewModel()
 
@@ -27,6 +31,16 @@ class HelloFragment : Fragment(R.layout.fragment_hello), MavericksView {
             is Uninitialized, is Loading -> getString(R.string.hello_fragment_loading_text)
             is Success -> state.message()
             is Fail -> getString(R.string.hello_fragment_failure_text)
+        }
+    }
+
+    override fun provideMocks(): MavericksViewMocks<out MockableMavericksView, out Parcelable> = mockSingleViewModel(
+        viewModelReference = HelloFragment::viewModel,
+        defaultState = HelloDaggerState(),
+        defaultArgs = null
+    ) {
+        state("successfully") {
+            copy(message = Success("I haz loaded"))
         }
     }
 }

--- a/hellodagger/src/main/java/com/airbnb/mvrx/hellodagger/HelloFragment.kt
+++ b/hellodagger/src/main/java/com/airbnb/mvrx/hellodagger/HelloFragment.kt
@@ -39,8 +39,8 @@ class HelloFragment : Fragment(R.layout.fragment_hello), MockableMavericksView {
         defaultState = HelloDaggerState(),
         defaultArgs = null
     ) {
-        state("successfully") {
-            copy(message = Success("I haz loaded"))
+        state("Success") {
+            copy(message = Success("Hello World"))
         }
     }
 }

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/lifecycleAwareLazy.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/lifecycleAwareLazy.kt
@@ -31,14 +31,12 @@ class lifecycleAwareLazy<out T>(private val owner: LifecycleOwner, initializer: 
     init {
         // owner.lifecycle.addObserver must be invoked on main thread otherwise addObserver will throw an IllegalStateException.
         // createUnsafe disables the main thread check.
-        synchronized(lock) {
-            LifecycleRegistry.createUnsafe(owner).addObserver(object : DefaultLifecycleObserver {
-                override fun onCreate(owner: LifecycleOwner) {
-                    if (!isInitialized()) value
-                    owner.lifecycle.removeObserver(this)
-                }
-            })
-        }
+        LifecycleRegistry.createUnsafe(owner).addObserver(object : DefaultLifecycleObserver {
+            override fun onCreate(owner: LifecycleOwner) {
+                if (!isInitialized()) value
+                owner.lifecycle.removeObserver(this)
+            }
+        })
     }
 
     @Suppress("LocalVariableName")


### PR DESCRIPTION
[lifecycle#2.3.0](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.3.0) throws IllegalStateException if the addObserver is invoked outside of the main thread. 

As per the suggestion in the change notes I added a `synchronized` block and use `createUnsafe`. 

I edited the helloDagger module to demo the error and you get the crash once you try opening the `HelloFragment` after launching the `MavericksLauncherActivity`. I did using the adb shell.
```
adb shell am start -n com.airbnb.mvrx.helloDagger/com.airbnb.mvrx.launcher.MavericksLauncherActivity
```

I left the demo code in this PR to make checking before/after the change easier. I'm actually not sure how to add a test for this outside of a manual check.

```
java.lang.IllegalStateException: Method addObserver must be called on the main thread
        at androidx.lifecycle.LifecycleRegistry.enforceMainThreadIfNeeded(LifecycleRegistry.java:317)
        at androidx.lifecycle.LifecycleRegistry.addObserver(LifecycleRegistry.java:172)
        at com.airbnb.mvrx.lifecycleAwareLazy.observerLifecycle(lifecycleAwareLazy.kt:40)
        at com.airbnb.mvrx.lifecycleAwareLazy.<init>(lifecycleAwareLazy.kt:36)
        at com.airbnb.mvrx.mocking.MockViewModelDelegateFactory.createLazyViewModel(MockViewModelDelegateFactory.kt:58)
        at com.airbnb.mvrx.hellodagger.HelloFragment$$special$$inlined$fragmentViewModel$2.provideDelegate(ViewModelDelegateProvider.kt:23)
        at com.airbnb.mvrx.hellodagger.HelloFragment$$special$$inlined$fragmentViewModel$2.provideDelegate(ViewModelDelegateProvider.kt:17)
        at com.airbnb.mvrx.hellodagger.HelloFragment.<init>(HelloFragment.kt:57)
        at java.lang.Class.newInstance(Native Method)
        at com.airbnb.mvrx.mocking.ViewMockerKt$getMockVariants$2.invoke(ViewMocker.kt:87)
        at com.airbnb.mvrx.mocking.ViewMockerKt$getMockVariants$2.invoke(Unknown Source:4)
        at com.airbnb.mvrx.mocking.ViewMockerKt$getMockVariants$3.invoke(ViewMocker.kt:96)
        at com.airbnb.mvrx.mocking.ViewMockerKt$getMockVariants$3.invoke(Unknown Source:4)
        at com.airbnb.mvrx.mocking.ViewMockerKt.getMockVariants(ViewMocker.kt:126)
        at com.airbnb.mvrx.mocking.ViewMockerKt.getMockVariants(ViewMocker.kt:94)
        at com.airbnb.mvrx.mocking.ViewMockerKt.getMockVariants$default(ViewMocker.kt:92)
        at com.airbnb.mvrx.launcher.MavericksLauncherFragment.getMocksForSelectedView(MavericksLauncherFragment.kt:91)
        at com.airbnb.mvrx.launcher.MavericksLauncherFragment.access$getMocksForSelectedView$p(MavericksLauncherFragment.kt:34)
        at com.airbnb.mvrx.launcher.MavericksLauncherFragment$epoxyController$1.invoke(MavericksLauncherFragment.kt:141)
        at com.airbnb.mvrx.launcher.MavericksLauncherFragment$epoxyController$1.invoke(MavericksLauncherFragment.kt:34)
        at com.airbnb.mvrx.launcher.MavericksEpoxyControllerKt$simpleController$2$1.invoke(MavericksEpoxyController.kt:47)
        at com.airbnb.mvrx.launcher.MavericksEpoxyControllerKt$simpleController$2$1.invoke(Unknown Source:2)
        at com.airbnb.mvrx.StateContainerKt.withState(StateContainer.kt:6)
        at com.airbnb.mvrx.launcher.MavericksEpoxyControllerKt$simpleController$2.invoke(MavericksEpoxyController.kt:46)
        at com.airbnb.mvrx.launcher.MavericksEpoxyControllerKt$simpleController$2.invoke(Unknown Source:2)
        at com.airbnb.mvrx.launcher.MavericksEpoxyController.buildModels(MavericksEpoxyController.kt:21)
        at com.airbnb.epoxy.EpoxyController$1.run(EpoxyController.java:281)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:223)
        at android.os.HandlerThread.run(HandlerThread.java:67)
```
