### PR TITLE
Remove createUnsafe and don't auto-subscribe on background threads

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/lifecycleAwareLazy.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/lifecycleAwareLazy.kt
@@ -3,6 +3,8 @@
 package com.airbnb.mvrx
 
 import android.annotation.SuppressLint
+import android.os.Handler
+import android.os.Looper
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
@@ -30,13 +32,14 @@ class lifecycleAwareLazy<out T>(private val owner: LifecycleOwner, initializer: 
 
     init {
         // owner.lifecycle.addObserver must be invoked on main thread otherwise addObserver will throw an IllegalStateException.
-        // createUnsafe disables the main thread check.
-        LifecycleRegistry.createUnsafe(owner).addObserver(object : DefaultLifecycleObserver {
-            override fun onCreate(owner: LifecycleOwner) {
-                if (!isInitialized()) value
-                owner.lifecycle.removeObserver(this)
-            }
-        })
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            owner.lifecycle.addObserver(object : DefaultLifecycleObserver {
+                override fun onCreate(owner: LifecycleOwner) {
+                    if (!isInitialized()) value
+                    owner.lifecycle.removeObserver(this)
+                }
+            })
+        }
     }
 
     @Suppress("LocalVariableName")

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/LifecycleAwareLazyTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/LifecycleAwareLazyTest.kt
@@ -1,6 +1,7 @@
 package com.airbnb.mvrx
 
 import androidx.lifecycle.Lifecycle
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -52,5 +53,29 @@ class LifecycleAwareLazyTest : BaseTest() {
         owner.lifecycle.currentState = Lifecycle.State.DESTROYED
         lazyProp = lifecycleAwareLazy(owner, { false }) { "Hello World" }
         assertFalse(lazyProp.isInitialized())
+    }
+
+    @Test
+    fun testNotInitializedIfDestroyed() {
+        owner.lifecycle.currentState = Lifecycle.State.CREATED
+        owner.lifecycle.currentState = Lifecycle.State.DESTROYED
+        val destroyedLazyProp = lifecycleAwareLazy(owner) { "Hello World" }
+        assertFalse(destroyedLazyProp.isInitialized())
+    }
+
+    @Test
+    fun testNoObserverIsAddedIfAlreadyInCreatedState() {
+        val alreadyCreatedOwner = TestLifecycleOwner()
+        alreadyCreatedOwner.lifecycle.currentState = Lifecycle.State.CREATED
+        val createdLazy = lifecycleAwareLazy(alreadyCreatedOwner) { "Hello World" }
+        assertTrue(createdLazy.isInitialized())
+        assertEquals(0, alreadyCreatedOwner.observerAddedCount)
+    }
+
+    @Test
+    fun testOneObserverIsAddedIfStateIsInitialized() {
+        owner.lifecycle.currentState = Lifecycle.State.INITIALIZED
+        assertFalse(lazyProp.isInitialized())
+        assertEquals(1, owner.observerAddedCount)
     }
 }

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/LifecycleAwareLazyTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/LifecycleAwareLazyTest.kt
@@ -36,4 +36,21 @@ class LifecycleAwareLazyTest : BaseTest() {
         lazyProp = lifecycleAwareLazy(owner) { "Hello World" }
         assertTrue(lazyProp.isInitialized())
     }
+
+    @Test
+    fun testInitializedIfOnBackgroundThread() {
+        owner.lifecycle.currentState = Lifecycle.State.STARTED
+        lazyProp = lifecycleAwareLazy(owner, { false }) { "Hello World" }
+        assertTrue(lazyProp.isInitialized())
+    }
+
+    @Test
+    fun testIsNotInitializedIfOnBackgroundThreadAndDestroyed() {
+        // Lifecycle can't move from an INITIALIZED to DESTROYED state.
+        // So, we need to first we move it into a created state.
+        owner.lifecycle.currentState = Lifecycle.State.CREATED
+        owner.lifecycle.currentState = Lifecycle.State.DESTROYED
+        lazyProp = lifecycleAwareLazy(owner, { false }) { "Hello World" }
+        assertFalse(lazyProp.isInitialized())
+    }
 }

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/TestLifecycleOwner.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/TestLifecycleOwner.kt
@@ -1,11 +1,19 @@
 package com.airbnb.mvrx
 
+import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 
 class TestLifecycleOwner : LifecycleOwner {
 
-    private val _lifecycle = LifecycleRegistry(this)
+    var observerAddedCount = 0
+
+    private val _lifecycle = object : LifecycleRegistry(this) {
+        override fun addObserver(observer: LifecycleObserver) {
+            observerAddedCount += 1
+            super.addObserver(observer)
+        }
+    }
 
     override fun getLifecycle(): LifecycleRegistry = _lifecycle
 }


### PR DESCRIPTION
Turns out `createUnsafe` does not work… at least, it breaks more than it fixes 😅 I double-checked all the test and ran a few demo apps to check.

I think a safer fallback is if the ViewModel is been created off the main thread then you must manually trigger the initialize by reading the ViewModel. The Mockables seemed fine in the limited test. helloDagger and the sample projects all seem to work fine with this method.

Sorry about this @gpeal I should have been more thorough in my testing, I got too focused on just the mockable not crashing.