### PR TITLE
 Fix subscriptionLifecycleOwner to use viewLifecycleOwner in Fragment's onCreateView

### DIFF
--- a/mvrx-rxjava2/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
+++ b/mvrx-rxjava2/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
@@ -1,7 +1,8 @@
 package com.airbnb.mvrx
 
-import io.reactivex.disposables.Disposables
+import io.reactivex.disposables.Disposable
 import kotlinx.coroutines.Job
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.reflect.KProperty1
 
 /**
@@ -211,6 +212,16 @@ interface MvRxView : MavericksView {
     ).toDisposable()
 }
 
-private fun Job.toDisposable() = Disposables.fromAction {
-    cancel()
+private class JobDisposable(job: Job) : AtomicReference<Job>(job), Disposable {
+    init {
+        job.invokeOnCompletion { set(null) }
+    }
+
+    override fun dispose() {
+        getAndSet(null)?.cancel()
+    }
+
+    override fun isDisposed(): Boolean = get()?.isActive?.not() ?: true
 }
+
+private fun Job.toDisposable(): Disposable = JobDisposable(this)

--- a/mvrx-rxjava2/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
+++ b/mvrx-rxjava2/src/main/kotlin/com/airbnb/mvrx/MvRxView.kt
@@ -224,4 +224,4 @@ private class JobDisposable(job: Job) : AtomicReference<Job>(job), Disposable {
     override fun isDisposed(): Boolean = get()?.isActive?.not() ?: true
 }
 
-private fun Job.toDisposable(): Disposable = JobDisposable(this)
+internal fun Job.toDisposable(): Disposable = JobDisposable(this)

--- a/mvrx-rxjava2/src/test/kotlin/com/airbnb/mvrx/DisposableJobTest.kt
+++ b/mvrx-rxjava2/src/test/kotlin/com/airbnb/mvrx/DisposableJobTest.kt
@@ -1,0 +1,42 @@
+package com.airbnb.mvrx
+
+import io.reactivex.disposables.Disposable
+import kotlinx.coroutines.CompletableJob
+import kotlinx.coroutines.Job
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class DisposableJobTest {
+    private lateinit var job: CompletableJob
+    private lateinit var disposable: Disposable
+
+    @Before
+    fun setup() {
+        job = Job()
+        disposable = job.toDisposable()
+    }
+
+    @Test
+    fun `dispose() cancels job`() {
+        disposable.dispose()
+        assert(job.isCancelled)
+        assert(disposable.isDisposed)
+    }
+
+    @Test
+    fun `isDisposed reflects job cancellation`() {
+        assert(!disposable.isDisposed)
+        job.cancel()
+        assert(disposable.isDisposed)
+    }
+
+    @Test
+    fun `isDisposed reflects job completion`() {
+        assert(!disposable.isDisposed)
+        job.complete()
+        assert(disposable.isDisposed)
+    }
+}

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksView.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksView.kt
@@ -70,7 +70,11 @@ interface MavericksView : LifecycleOwner {
      * By default [subscriptionLifecycleOwner] is the same as the MvRxView's standard lifecycle owner.
      */
     val subscriptionLifecycleOwner: LifecycleOwner
-        get() = (this as? Fragment)?.viewLifecycleOwnerLiveData?.value ?: this
+        get() = try {
+            (this as? Fragment)?.viewLifecycleOwner ?: this
+        } catch(e: IllegalStateException) {
+            this
+        }
 
     fun postInvalidate() {
         if (pendingInvalidates.add(System.identityHashCode(this@MavericksView))) {

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksView.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksView.kt
@@ -57,17 +57,16 @@ interface MavericksView : LifecycleOwner {
 
     /**
      * The [LifecycleOwner] to use when making new subscriptions. You may want to return different owners depending
-     * on what state your [MavericksView] is in. For fragments, subscriptions made in `onCreate` should use
-     * the fragment's lifecycle owner so that the subscriptions are cleared in `onDestroy`. Subscriptions made in or after
-     * `onCreateView` should use the fragment's _view's_ lifecycle owner so that they are cleared in `onDestroyView`.
+     * on what state your [MavericksView] is in.
      *
-     * For example, if you are using a fragment as a [MavericksView] the proper implementation is:
-     * ```
-     *     override val subscriptionLifecycleOwner: LifecycleOwner
-     *        get() = this.viewLifecycleOwnerLiveData.value ?: this
-     * ```
+     * Fragments are handled by the default implementation using their standard lifecycle owner for subscriptions made
+     * in `onCreate` (cleared in `onDestroy`), or their _view_ lifecycle owner for subscriptions made in or
+     * after `onCreateView` (cleared in `onDestroyView`). Using [Fragment.getViewLifecycleOwner] is necessary to
+     * retrieve the view's lifecycle as early as `onCreateView`. This method throws an `IllegalStateException` when view
+     * lifecycle is unavailable (eg. _before_ `onCreateView`) which is caught as a signal to fall back to the fragment's
+     * standard lifecycle owner.
      *
-     * By default [subscriptionLifecycleOwner] is the same as the MvRxView's standard lifecycle owner.
+     * For non-Fragments the default [subscriptionLifecycleOwner] is the same as the MvRxView's standard lifecycle owner.
      */
     val subscriptionLifecycleOwner: LifecycleOwner
         get() = try {


### PR DESCRIPTION
As discussed in #530, `subscriptionLifecycleowner` wasn't using a fragment's `viewLifecycleOwner` for subscriptions made during `onCreateView`. The previous implementation using `viewLifecycleOwnerLiveData` doesn't work there due to the LiveData's value remaining `null` until the view has been returned. New solution uses `viewLifecycleOwner` directly when available - exception for accessing too early is caught.

Also included is a new wrapper for `Job` in `mvrx-rxjava2` to better reflect the status of the underlying job in the returned `Disposable`'s `isDisposed()`.