### PR TITLE
Error handling enhancements

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModel.kt
@@ -186,7 +186,7 @@ abstract class MavericksViewModel<S : MavericksState>(
      * @param reducer A reducer that is applied to the current state and should return the new state. Because the state is the receiver
      *                and is likely a data class, an implementation may look like: `{ copy(response = it) }`.
      */
-    protected fun <T : Any?> Deferred<T>.execute(
+    protected open fun <T : Any?> Deferred<T>.execute(
         dispatcher: CoroutineDispatcher? = null,
         retainValue: KProperty1<S, Async<T>>? = null,
         reducer: S.(Async<T>) -> S
@@ -203,7 +203,7 @@ abstract class MavericksViewModel<S : MavericksState>(
      * @param reducer A reducer that is applied to the current state and should return the new state. Because the state is the receiver
      *                and is likely a data class, an implementation may look like: `{ copy(response = it) }`.
      */
-    protected fun <T : Any?> (suspend () -> T).execute(
+    protected open fun <T : Any?> (suspend () -> T).execute(
         dispatcher: CoroutineDispatcher? = null,
         retainValue: KProperty1<S, Async<T>>? = null,
         reducer: S.(Async<T>) -> S
@@ -243,7 +243,7 @@ abstract class MavericksViewModel<S : MavericksState>(
      * @param reducer A reducer that is applied to the current state and should return the new state. Because the state is the receiver
      *                and is likely a data class, an implementation may look like: `{ copy(response = it) }`.
      */
-    protected fun <T> Flow<T>.execute(
+    protected open fun <T> Flow<T>.execute(
         dispatcher: CoroutineDispatcher? = null,
         retainValue: KProperty1<S, Async<T>>? = null,
         reducer: S.(Async<T>) -> S
@@ -272,7 +272,7 @@ abstract class MavericksViewModel<S : MavericksState>(
      * @param reducer A reducer that is applied to the current state and should return the new state. Because the state is the receiver
      *                and is likely a data class, an implementation may look like: `{ copy(response = it) }`.
      */
-    protected fun <T> Flow<T>.setOnEach(
+    protected open fun <T> Flow<T>.setOnEach(
         dispatcher: CoroutineDispatcher? = null,
         reducer: S.(T) -> S
     ): Job {

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModel.kt
@@ -226,7 +226,7 @@ abstract class MavericksViewModel<S : MavericksState>(
             } catch (e: CancellationException) {
                 @Suppress("RethrowCaughtException")
                 throw e
-            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            } catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
                 setState { reducer(Fail(e, value = retainValue?.get(this)?.invoke())) }
             }
         }


### PR DESCRIPTION
Minor enhancements, that allow for better error handling in `execute` functions:

- Catch `Throwable` instead of `Exception` - to handle wider range of errors
- Mark `execute` and `setOnEach` functions as `open`, so user can override them to enhance `Async` handling (for example by adding logging)

More context at #535 