### PR TITLE
Release 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Change Log
+
+## 2.3.0
+- Error handling enhancements (#540)
+- Upgraded Compose to beta07 (#549)
+
+Note: Compose support is experimental and mvrx-compose artifact is at version 2.1.0-alpha02
+
 ## 2.2.0
 - Fix subscriptionLifecycleOwner to use viewLifecycleOwner in Fragment's onCreateView (#533)
 - Remove createUnsafe and don't auto-subscribe on background threads (#525)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.3.0-SNAPSHOT
+VERSION_NAME=2.4.0-SNAPSHOT
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Mavericks is an Android application framework that makes product development fast and fun.
 POM_URL=https://github.com/airbnb/mavericks

--- a/mvrx-compose/gradle.properties
+++ b/mvrx-compose/gradle.properties
@@ -2,4 +2,4 @@ POM_NAME=Mavericks Compose
 POM_ARTIFACT_ID=mavericks-compose
 POM_PACKAGING=aar
 GROUP=com.airbnb.android
-VERSION_NAME=2.1.0-alpha02-SNAPSHOT
+VERSION_NAME=2.1.0-alpha03-SNAPSHOT


### PR DESCRIPTION
## 2.3.0
- Error handling enhancements (#540)
- Upgraded Compose to beta07 (#549)
- 
Note: Compose support is experimental and mvrx-compose artifact is at version 2.1.0-alpha02