### PR TITLE
Bumps AGP and Hilt versions to unblock development

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 dependencies {
     implementation(gradleApi())
-    implementation("com.android.tools.build:gradle:7.0.0-beta01")
+    implementation("com.android.tools.build:gradle:7.0.0-beta03")
     implementation("org.jacoco:org.jacoco.core:0.8.5")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32")
 }

--- a/buildSrc/src/main/java/dependencies.kt
+++ b/buildSrc/src/main/java/dependencies.kt
@@ -2,7 +2,7 @@ object Versions {
     // Build tools and SDK
     const val buildTools = "30.0.3"
     const val compileSdk = 30
-    const val gradlePlugin = "7.0.0-beta01"
+    const val gradlePlugin = "7.0.0-beta03"
     const val kotlin = "1.4.32"
     const val minSdk = 16
     const val targetSdk = 29
@@ -29,7 +29,7 @@ object Versions {
     const val autoValue = "1.6.6"
     const val dagger = "2.31.2"
     const val epoxy = "4.0.0"
-    const val hilt = "2.31.1-alpha"
+    const val hilt = "2.36"
     const val koin = "2.0.1"
     const val kotlinCoroutines = "1.4.3"
     const val lottie = "3.4.0"


### PR DESCRIPTION
When using Android Studio Arctic Fox, the current AGP version errors during sync with 
```
Gradle sync failed: Invalid injected android support version '202.7660.26.42.7322048', expected to be of the form 'w.x.y.z'
```

See https://issuetracker.google.com/issues/187470273