### PR TITLE
Fix typo

### DIFF
--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -113,7 +113,7 @@ Most of the time, overriding `invalidate()` and updating your views is sufficien
 #### Accessing state once
 If you just want to retrieve the value of state one time, you can use `withState { state -> ... }`.
 
-When called from outside a ViewModel, this will _is_ be run synchronously.
+When called from outside a ViewModel, this will be run synchronously.
 
 #### Triggering state changes
 The ViewModel should expose named functions that can be called by the view. For example, a counter view model could expose a function `incrementCount()` to create a clear API accessible to the view.


### PR DESCRIPTION
The sentence now uses similar language as on line 93:
https://github.com/airbnb/mavericks/blob/2.3.0/docs/core-concepts.md?plain=1#L93

> [...] this will _not_ be run synchronously. [...]