### PR TITLE
Add covariant recreation support

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 dependencies {
     implementation(gradleApi())
-    implementation("com.android.tools.build:gradle:7.0.0-beta03")
+    implementation("com.android.tools.build:gradle:7.0.0")
     implementation("org.jacoco:org.jacoco.core:0.8.5")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32")
 }

--- a/buildSrc/src/main/java/dependencies.kt
+++ b/buildSrc/src/main/java/dependencies.kt
@@ -2,7 +2,7 @@ object Versions {
     // Build tools and SDK
     const val buildTools = "30.0.3"
     const val compileSdk = 30
-    const val gradlePlugin = "7.0.0-beta03"
+    const val gradlePlugin = "7.0.0"
     const val kotlin = "1.4.32"
     const val minSdk = 16
     const val targetSdk = 29

--- a/mvrx-mocking/src/main/kotlin/com/airbnb/mvrx/mocking/MockViewModelDelegateFactory.kt
+++ b/mvrx-mocking/src/main/kotlin/com/airbnb/mvrx/mocking/MockViewModelDelegateFactory.kt
@@ -3,17 +3,18 @@ package com.airbnb.mvrx.mocking
 import androidx.fragment.app.Fragment
 import com.airbnb.mvrx.ActivityViewModelContext
 import com.airbnb.mvrx.Mavericks
-import com.airbnb.mvrx.MavericksView
-import com.airbnb.mvrx.MavericksViewModel
 import com.airbnb.mvrx.MavericksState
 import com.airbnb.mvrx.MavericksStateFactory
+import com.airbnb.mvrx.MavericksView
+import com.airbnb.mvrx.MavericksViewModel
 import com.airbnb.mvrx.MavericksViewModelProvider
 import com.airbnb.mvrx.RealMavericksStateFactory
+import com.airbnb.mvrx.StateRestorer
 import com.airbnb.mvrx.ViewModelContext
 import com.airbnb.mvrx.ViewModelDelegateFactory
 import com.airbnb.mvrx.ViewModelDoesNotExistException
-import com.airbnb.mvrx.lifecycleAwareLazy
 import com.airbnb.mvrx._internal
+import com.airbnb.mvrx.lifecycleAwareLazy
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
@@ -130,7 +131,7 @@ class MockViewModelDelegateFactory(
                         viewModelClass: Class<out VM>,
                         stateClass: Class<out S>,
                         viewModelContext: ViewModelContext,
-                        stateRestorer: (S) -> S
+                        stateRestorer: StateRestorer<VM, S>?
                     ): S {
                         //  Throwing this indicates to us that the view model didn't exist,
                         // since the factory will only be invoked when creating a new view model.
@@ -195,7 +196,7 @@ class MockViewModelDelegateFactory(
                     viewModelClass: Class<out VM>,
                     stateClass: Class<out S>,
                     viewModelContext: ViewModelContext,
-                    stateRestorer: (S) -> S
+                    stateRestorer: StateRestorer<VM, S>?
                 ): S {
                     return mockState
                 }

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelProvider.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelProvider.kt
@@ -104,7 +104,7 @@ object MavericksViewModelProvider {
         val restoredStateClass = getSerializable(KEY_MVRX_SAVED_STATE_CLASS) as? Class<out S>
 
         requireNotNull(restoredState) { "State was not saved prior to restoring!" }
-        requireNotNull(restoredViewModelClass) { "Viewmodel class was not properly saved prior to restoring!" }
+        requireNotNull(restoredViewModelClass) { "ViewModel class was not properly saved prior to restoring!" }
         requireNotNull(restoredStateClass) { "State class was not properly saved prior to restoring!" }
 
         val restoredContext = when (viewModelContext) {

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelProvider.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelProvider.kt
@@ -44,7 +44,7 @@ object MavericksViewModelProvider {
 
         val stateRestorer = savedStateRegistry
             .consumeRestoredStateForKey(key)
-            ?.toStateRestorer<S>(viewModelContext)
+            ?.toStateRestorer<VM, S>(viewModelContext)
 
         val restoredContext = stateRestorer?.viewModelContext ?: viewModelContext
 
@@ -56,7 +56,7 @@ object MavericksViewModelProvider {
                 stateClass,
                 restoredContext,
                 key,
-                stateRestorer?.toRestoredState,
+                stateRestorer,
                 forExistingViewModel,
                 initialStateFactory
             )
@@ -81,6 +81,11 @@ object MavericksViewModelProvider {
     ) = withState(this) { state ->
         Bundle().apply {
             putBundle(KEY_MVRX_SAVED_INSTANCE_STATE, state.persistState())
+
+            // Save the resolved types of the ViewModel and State in the bundle so we can recreate them even if the first declaration invoked does not know the types
+            putSerializable(KEY_MVRX_SAVED_VM_CLASS, this@getSavedStateBundle::class.java)
+            putSerializable(KEY_MVRX_SAVED_STATE_CLASS, state::class.java)
+
             initialArgs?.let { args ->
                 when (args) {
                     is Parcelable -> putParcelable(KEY_MVRX_SAVED_ARGS, args)
@@ -91,21 +96,28 @@ object MavericksViewModelProvider {
         }
     }
 
-    private fun <S : MavericksState> Bundle.toStateRestorer(viewModelContext: ViewModelContext): StateRestorer<S> {
+    @Suppress("UNCHECKED_CAST")
+    private fun <VM : MavericksViewModel<S>, S : MavericksState> Bundle.toStateRestorer(viewModelContext: ViewModelContext): StateRestorer<VM, S> {
         val restoredArgs = get(KEY_MVRX_SAVED_ARGS)
         val restoredState = getBundle(KEY_MVRX_SAVED_INSTANCE_STATE)
+        val restoredViewModelClass = getSerializable(KEY_MVRX_SAVED_VM_CLASS) as? Class<out VM>
+        val restoredStateClass = getSerializable(KEY_MVRX_SAVED_STATE_CLASS) as? Class<out S>
 
         requireNotNull(restoredState) { "State was not saved prior to restoring!" }
+        requireNotNull(restoredViewModelClass) { "Viewmodel class was not properly saved prior to restoring!" }
+        requireNotNull(restoredStateClass) { "State class was not properly saved prior to restoring!" }
 
         val restoredContext = when (viewModelContext) {
             is ActivityViewModelContext -> viewModelContext.copy(args = restoredArgs)
             is FragmentViewModelContext -> viewModelContext.copy(args = restoredArgs)
         }
-        return StateRestorer(restoredContext) { restoredState.restorePersistedState(it) }
+        return StateRestorer(restoredContext, restoredViewModelClass, restoredStateClass) { restoredState.restorePersistedState(it) }
     }
 
     private const val KEY_MVRX_SAVED_INSTANCE_STATE = "mvrx:saved_instance_state"
     private const val KEY_MVRX_SAVED_ARGS = "mvrx:saved_args"
+    private const val KEY_MVRX_SAVED_VM_CLASS = "mvrx:saved_viewmodel_class"
+    private const val KEY_MVRX_SAVED_STATE_CLASS = "mvrx:saved_state_class"
 }
 
 /**
@@ -131,7 +143,9 @@ internal fun Class<*>.instance(): Any {
 internal const val ACCESSED_BEFORE_ON_CREATE_ERR_MSG =
     "You can only access a view model after super.onCreate of your activity/fragment has been called."
 
-private data class StateRestorer<S : MavericksState>(
+data class StateRestorer<VM : MavericksViewModel<S>, S : MavericksState>(
     val viewModelContext: ViewModelContext,
+    val viewModelClass: Class<out VM>,
+    val stateClass: Class<out S>,
     val toRestoredState: (S) -> S
 )

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/StateRestorationTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/StateRestorationTest.kt
@@ -1,0 +1,63 @@
+package com.airbnb.mvrx
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import org.junit.Test
+import org.robolectric.Robolectric
+
+class StateRestorationTest : BaseTest() {
+    @Test
+    fun testStateRestorationWithBaseTypeDeclarationSucceeds() {
+        // Attach an instance of Fragment1, causing the ChildViewModel to be initialized
+        val (activityController, fragment1) = createFragment<Fragment1, TestActivity>()
+        // Remove Fragment1 from the Activity backstack so we don't try to restore it
+        activityController.get().supportFragmentManager.beginTransaction().remove(fragment1).commitNow()
+        // Save the Mavericks state of the Activity into a Bundle
+        val bundle = Bundle()
+        activityController.saveInstanceState(bundle)
+
+        // Restore a new Activity with the previously saved state and attach an instance of Fragment2
+        // This mimics the app process being restored with Fragment2 on top of the backstack, which we don't have the ability to directly test
+        val newController = Robolectric.buildActivity(TestActivity::class.java)
+        newController.setup(bundle)
+        val activity = newController.get()
+        Fragment2().apply {
+            activity.supportFragmentManager
+                .beginTransaction()
+                .add(this, "TAG")
+                .commitNow()
+        }
+    }
+
+    abstract class ParentViewModel<S : ParentState>(initialState: S) : MavericksViewModel<S>(initialState)
+
+    abstract class ParentState : MavericksState
+
+    class ChildViewModel(initialState: ChildState) : ParentViewModel<ChildState>(initialState)
+
+    data class ChildState(val string: String = "value") : ParentState()
+
+    class Fragment1 : Fragment(), MavericksView {
+        private val activityVm: ChildViewModel by activityViewModel { viewModelKey }
+
+        override fun invalidate() {}
+    }
+
+    /**
+     * This Fragment is intended to be attached after [Fragment1], and declares a [ParentViewModel] instead of [ChildViewModel]. This simulates
+     * a setup where [Fragment2] does not have access to the [ChildViewModel] class at compile time.
+     */
+    class Fragment2 : Fragment(), MavericksView {
+        /**
+         * We need to use a shared key for retrieving the ViewModel, because Mavericks will otherwise use the declaration site class, which is
+         * abstract in this case - we want to retrieve the [ChildViewModel] initialized by [Fragment1]
+         */
+        private val existingVm: ParentViewModel<ParentState> by existingViewModel { viewModelKey }
+
+        override fun invalidate() {}
+    }
+
+    companion object {
+        const val viewModelKey = "key for retrieving ChildViewModel"
+    }
+}


### PR DESCRIPTION
Adds support for recreating MavericksViewModels and MavericksState from a persisted Bundle when the declaration site uses a covariant type. This is accomplished by serializing the Java Class of both the ViewModel and State types, and storing them in the StateRestorer class. These values are then used in MavericksFactory and MavericksStateFactory if present, overriding the declaration site types.

Also adds a test in StateRestorationTest.kt to cover this newly supported behavior. Without these changes, the test fails with an IllegalStateException when trying to instantiate the abstract State class from the declaration site.