### PR TITLE
Add support for restoring ViewModels that were initially created with a companion factory in a superclass

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelProvider.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelProvider.kt
@@ -66,7 +66,7 @@ object MavericksViewModelProvider {
             // Save the view model's state to the bundle so that it can be used to recreate
             // state across system initiated process death.
             viewModelContext.savedStateRegistry.registerSavedStateProvider(key) {
-                viewModel.viewModel.getSavedStateBundle(restoredContext.args, viewModelClass)
+                viewModel.viewModel.getSavedStateBundle(restoredContext.args, viewModelClass, stateClass)
             }
         } catch (e: IllegalArgumentException) {
             // The view model was already registered with the context. We only want the initial
@@ -78,17 +78,17 @@ object MavericksViewModelProvider {
 
     private fun <VM : MavericksViewModel<S>, S : MavericksState> VM.getSavedStateBundle(
         initialArgs: Any?,
-        originalDeclarationViewModelClass: Class<out VM>
+        originalDeclarationViewModelClass: Class<out VM>,
+        originalDeclarationStateClass: Class<out S>
     ) = withState(this) { state ->
         Bundle().apply {
             putBundle(KEY_MVRX_SAVED_INSTANCE_STATE, state.persistState())
 
             // Save the types of the ViewModel and State in the bundle so we can recreate them even if the first declaration invoked does not have the
             // same types as the original declaration.
-            // We save the ViewModel class from the original declaration site so that we can use it to either call a companion factory if it is a superclass,
-            // or the constructor if it is not.
+            // We save the classes from the original declaration site rather than the resolved classes to ensure the recreation path is the same as the original.
             putSerializable(KEY_MVRX_SAVED_VM_CLASS, originalDeclarationViewModelClass)
-            putSerializable(KEY_MVRX_SAVED_STATE_CLASS, state::class.java)
+            putSerializable(KEY_MVRX_SAVED_STATE_CLASS, originalDeclarationStateClass)
 
             initialArgs?.let { args ->
                 when (args) {

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelProvider.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelProvider.kt
@@ -66,7 +66,7 @@ object MavericksViewModelProvider {
             // Save the view model's state to the bundle so that it can be used to recreate
             // state across system initiated process death.
             viewModelContext.savedStateRegistry.registerSavedStateProvider(key) {
-                viewModel.viewModel.getSavedStateBundle(restoredContext.args)
+                viewModel.viewModel.getSavedStateBundle(restoredContext.args, viewModelClass)
             }
         } catch (e: IllegalArgumentException) {
             // The view model was already registered with the context. We only want the initial
@@ -77,13 +77,17 @@ object MavericksViewModelProvider {
     }
 
     private fun <VM : MavericksViewModel<S>, S : MavericksState> VM.getSavedStateBundle(
-        initialArgs: Any?
+        initialArgs: Any?,
+        originalDeclarationViewModelClass: Class<out VM>
     ) = withState(this) { state ->
         Bundle().apply {
             putBundle(KEY_MVRX_SAVED_INSTANCE_STATE, state.persistState())
 
-            // Save the resolved types of the ViewModel and State in the bundle so we can recreate them even if the first declaration invoked does not know the types
-            putSerializable(KEY_MVRX_SAVED_VM_CLASS, this@getSavedStateBundle::class.java)
+            // Save the types of the ViewModel and State in the bundle so we can recreate them even if the first declaration invoked does not have the
+            // same types as the original declaration.
+            // We save the ViewModel class from the original declaration site so that we can use it to either call a companion factory if it is a superclass,
+            // or the constructor if it is not.
+            putSerializable(KEY_MVRX_SAVED_VM_CLASS, originalDeclarationViewModelClass)
             putSerializable(KEY_MVRX_SAVED_STATE_CLASS, state::class.java)
 
             initialArgs?.let { args ->

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/StateRestorationTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/StateRestorationTest.kt
@@ -57,6 +57,50 @@ class StateRestorationTest : BaseTest() {
         override fun invalidate() {}
     }
 
+    @Test
+    fun testStateRestorationWithBaseTypeDeclarationCorrectlyCallsFactoryInBaseType() {
+        // Attach an instance of FragmentWithParentViewModelWithFactory, causing its factory method to be called directly
+        val (activityController, _) = createFragment<FragmentWithParentViewModelWithFactory, TestActivity>()
+        // Save the Mavericks state of the Activity into a Bundle
+        val bundle = Bundle()
+        activityController.saveInstanceState(bundle)
+
+        // Restore a new Activity with the previously saved state. This mimics the app process being restored with Fragment3 still attached
+        val newController = Robolectric.buildActivity(TestActivity::class.java)
+        newController.setup(bundle)
+    }
+
+    /**
+     * This abstract ViewModel class must have its compnaion factory called on restoration, otherwise Mavericks cannot create an instance of
+     * its state class [StateWithNoDefaultConstructor], and a crash will occur.
+     */
+    abstract class ParentViewModelWithFactory(initialState: StateWithNoDefaultConstructor) :
+        MavericksViewModel<StateWithNoDefaultConstructor>(initialState) {
+        companion object : MavericksViewModelFactory<ParentViewModelWithFactory, StateWithNoDefaultConstructor> {
+
+            override fun initialState(viewModelContext: ViewModelContext): StateWithNoDefaultConstructor {
+                return StateWithNoDefaultConstructor("")
+            }
+
+            override fun create(viewModelContext: ViewModelContext, state: StateWithNoDefaultConstructor): ParentViewModelWithFactory {
+                return ChildViewModelOfParentWithFactory(state)
+            }
+        }
+    }
+
+    class ChildViewModelOfParentWithFactory(initialState: StateWithNoDefaultConstructor) : ParentViewModelWithFactory(initialState)
+
+    /**
+     * Because this has no default constructor, it must be provided via a companion factory, or else a crash will occur.
+     */
+    data class StateWithNoDefaultConstructor(val string: String) : MavericksState
+
+    class FragmentWithParentViewModelWithFactory : Fragment(), MavericksView {
+        private val parentViewModelWithFactory: ParentViewModelWithFactory by fragmentViewModel()
+
+        override fun invalidate() {}
+    }
+
     companion object {
         const val viewModelKey = "key for retrieving ChildViewModel"
     }

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/StateRestorationTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/StateRestorationTest.kt
@@ -71,7 +71,7 @@ class StateRestorationTest : BaseTest() {
     }
 
     /**
-     * This abstract ViewModel class must have its compnaion factory called on restoration, otherwise Mavericks cannot create an instance of
+     * This abstract ViewModel class must have its companion factory called on restoration, otherwise Mavericks cannot create an instance of
      * its state class [StateWithNoDefaultConstructor], and a crash will occur.
      */
     abstract class ParentViewModelWithFactory(initialState: StateWithNoDefaultConstructor) :


### PR DESCRIPTION
Companion factories may be declared in any superclass of a given Mavericks ViewModel. Therefore, when recreating an instance of a ViewModel, we need to store the ViewModel class from the declaration site, instead of the resolved class. In cases where a companion factory was used, we can call the same one that was used to initially create the ViewModel. If a companion factory was not used, we can safely call the constructor of the original declaration site class as before.

In situations where the State class does not have a default constructor and must be provided via a companion factory, this behavior was leading to a crash. This adds a unit test to `StateRestorationTest` that covers one such scenario.

@BenSchwab 