### PR TITLE
Handle repeated state restorations where declaration of ViewModel does not use original types

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelProvider.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModelProvider.kt
@@ -65,8 +65,14 @@ object MavericksViewModelProvider {
         try {
             // Save the view model's state to the bundle so that it can be used to recreate
             // state across system initiated process death.
+            // We use classes from the StateRestorer if present, because they represent the original declaration site of the ViewModel and are the ones
+            // we will eventually call for restoration.
             viewModelContext.savedStateRegistry.registerSavedStateProvider(key) {
-                viewModel.viewModel.getSavedStateBundle(restoredContext.args, viewModelClass, stateClass)
+                viewModel.viewModel.getSavedStateBundle(
+                    restoredContext.args,
+                    stateRestorer?.viewModelClass ?: viewModelClass,
+                    stateRestorer?.stateClass ?: stateClass
+                )
             }
         } catch (e: IllegalArgumentException) {
             // The view model was already registered with the context. We only want the initial


### PR DESCRIPTION
Covers an edge case from https://github.com/airbnb/mavericks/pull/566 - if we are saving state when a ViewModel is first created, we need to use the classes from the StateRestorer if it is present. In the case where we are restoring from a previously restored state, only the restored state has knowledge of the original declaration site classes that we need to call.

@BenSchwab 