### PR TITLE
#569: Updated Compose to latest, and Kotlin to latest compatible version

### DIFF
--- a/buildSrc/src/main/java/dependencies.kt
+++ b/buildSrc/src/main/java/dependencies.kt
@@ -3,19 +3,19 @@ object Versions {
     const val buildTools = "30.0.3"
     const val compileSdk = 30
     const val gradlePlugin = "7.0.0"
-    const val kotlin = "1.4.32"
+    const val kotlin = "1.5.21"
     const val minSdk = 16
     const val targetSdk = 29
 
     // Android libraries
     const val activity = "1.2.3"
-    const val activityCompose = "1.3.0-alpha08"
+    const val activityCompose = "1.3.1"
     const val appcompat = "1.3.0"
     const val arch = "2.1.0"
     const val cardview = "1.0.0"
     const val constraintlayout = "2.0.0"
     const val coordinatorLayout = "1.1.0"
-    const val compose = "1.0.0-beta07"
+    const val compose = "1.0.1"
     const val core = "1.5.0"
     const val fragment = "1.3.4"
     const val lifecycle = "2.3.1"


### PR DESCRIPTION
According to the Mavericks team `./gradlew detekt` should run all the checks. It reports no issues with this change, so I think it's ready to submit upstream. 