### PR TITLE
Ignore VerifyError Exception when loading potential mockable classes

### DIFF
--- a/launcher/src/main/java/com/airbnb/mvrx/launcher/MavericksGlobalMockLibrary.kt
+++ b/launcher/src/main/java/com/airbnb/mvrx/launcher/MavericksGlobalMockLibrary.kt
@@ -125,6 +125,8 @@ private fun getAsMavericksView(
         classLoader.loadClass(className)
     } catch (e: ClassNotFoundException) {
         return null
+    } catch (e: VerifyError) {
+        return null
     }
 
     return if (MockableMavericksView::class.java.isAssignableFrom(clazz) && !Modifier.isAbstract(clazz.modifiers)) {


### PR DESCRIPTION
This pr resolves the following issue:
https://github.com/airbnb/mavericks/issues/574

I have tested this on my local machine with success.
Please note that I was required to perform the following additions to test, while leaving them out of the PR for obvious reasons.

1. add jcenter() as a repository to resolve an error:
```
 Could not resolve all files for configuration ':launcher:dokkaHtmlPlugin'.
   > Could not find org.jetbrains.kotlinx:kotlinx-html-jvm:0.7.2.
```
2. disable release signing to publish to my local maven with the following added to the project properties:
`RELEASE_SIGNING_ENABLED=false`
 