### PR TITLE
prepare for 2.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Change Log
+
+## 2.5.0
+- Fix issue when the LocalContext is not directly an Activity (#582)
+- update to Compose 1.0.4, Kotlin 1.5.31, Koin 3.1.3 (#586)
+- Ignore VerifyError Exception when loading potential mockable classes #590
+
 ## 2.4.0
 - Add covariant recreation support (#565)
 - Exposing unique subscription handling for custom flow operations (#560)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.4.0
+VERSION_NAME=2.5.0
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Mavericks is an Android application framework that makes product development fast and fun.
 POM_URL=https://github.com/airbnb/mavericks


### PR DESCRIPTION
- Fix issue when the LocalContext is not directly an Activity (#582)
- update to Compose 1.0.4, Kotlin 1.5.31, Koin 3.1.3 (#586)
- Ignore VerifyError Exception when loading potential mockable classes #590