### PR TITLE
Release 2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 2.5.1
+- Add ability to manually pass argument to composable viewModel factories (#595)
+- Fix Fragment arguments not being correctly passed to viewmodel state initialization in compose usage (#595)
+- Switch mavericks-compose artifact to use same versioning scheme as other artifacts
+
 ## 2.5.0
 - Fix issue when the LocalContext is not directly an Activity (#582)
 - update to Compose 1.0.4, Kotlin 1.5.31, Koin 3.1.3 (#586)

--- a/docs/jetpack-compose.md
+++ b/docs/jetpack-compose.md
@@ -2,7 +2,7 @@
 
 Mavericks is still useful in a Jetpack Compose world. With Jetpack Compose, you can use Compose for all of your UI but Mavericks for your business logic, data fetching, interface to your dependency injection object graph, etc.
 
-To use Mavericks with Jetpack Compose, add the `com.airbnb.android:mavericks-compose` artifact (2.1.0-alpha01).
+To use Mavericks with Jetpack Compose, add the `com.airbnb.android:mavericks-compose` artifact.
 
 ## Creating a MavericksViewModel
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.5.0
+VERSION_NAME=2.5.1
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Mavericks is an Android application framework that makes product development fast and fun.
 POM_URL=https://github.com/airbnb/mavericks

--- a/mvrx-compose/gradle.properties
+++ b/mvrx-compose/gradle.properties
@@ -2,4 +2,3 @@ POM_NAME=Mavericks Compose
 POM_ARTIFACT_ID=mavericks-compose
 POM_PACKAGING=aar
 GROUP=com.airbnb.android
-VERSION_NAME=2.1.0-alpha03-SNAPSHOT

--- a/mvrx-compose/src/main/kotlin/com/airbnb/mvrx/compose/MavericksComposeExtensions.kt
+++ b/mvrx-compose/src/main/kotlin/com/airbnb/mvrx/compose/MavericksComposeExtensions.kt
@@ -40,7 +40,11 @@ import kotlin.reflect.KProperty1
  *
  * To subscribe to this view model's state, call collectAsState(YourState::yourProp), collectAsState { it.yourProp } or collectAsState() on your view model.
  *
- * To pass an argument to viewModel from a composable function use [argsFactory]. The result from this function will be passed to your state constructor as a parameter.
+ * @param keyFactory Optionally provide a key to differentiate multiple viewmodels of the same type in the same scope. By default the key is the ViewModel
+ * java class name.
+ *
+ * @param argsFactory If present, the result from this function will be passed to your state constructor as a parameter when the viewmodel is first
+ * initialized. This will supersede any arguments from the fragment or activity.
  */
 @Composable
 inline fun <reified VM : MavericksViewModel<S>, reified S : MavericksState> mavericksViewModel(


### PR DESCRIPTION
## 2.5.1
- Add ability to manually pass argument to composable viewModel factories (#595)
- Fix Fragment arguments not being correctly passed to viewmodel state initialization in compose usage (#595)
- Switch mavericks-compose artifact to use same versioning scheme as other artifacts