### PR TITLE
Bump to 2.6.0 and add testing docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## 2.6.0
+Big thanks to @itsandreramon for contributing the two main improvements in this release!
+
+- Pre-configure Hilt by adding a new "mvrx-hilt" artifact (#598)
+
+See the updated Hilt documentation for guidance on how to more easily use Hilt with Mavericks https://airbnb.io/mavericks/#/dagger?id=hilt
+
+- Add support to use Mavericks with JUnit 5 (#600)
+
+See the new testing documentation at https://airbnb.io/mavericks/#/testing for details.
+
+- Don't expose lifecycleAwareLazy in viewModel return type (#603)
+
+
 ## 2.5.1
 - Add ability to manually pass argument to composable viewModel factories (#595)
 - Fix Fragment arguments not being correctly passed to viewmodel state initialization in compose usage (#595)

--- a/buildSrc/src/main/java/dependencies.kt
+++ b/buildSrc/src/main/java/dependencies.kt
@@ -1,9 +1,9 @@
 object Versions {
     // Build tools and SDK
-    const val buildTools = "30.0.3"
+    const val buildTools = "32.0.0"
     const val compileSdk = 31
-    const val gradlePlugin = "7.0.3"
-    const val kotlin = "1.5.31"
+    const val gradlePlugin = "7.1.0"
+    const val kotlin = "1.6.10"
     const val minSdk = 16
     const val targetSdk = 29
 
@@ -15,7 +15,7 @@ object Versions {
     const val cardview = "1.0.0"
     const val constraintlayout = "2.0.0"
     const val coordinatorLayout = "1.1.0"
-    const val compose = "1.0.4"
+    const val compose = "1.0.5"
     const val core = "1.5.0"
     const val fragment = "1.3.4"
     const val lifecycle = "2.3.1"

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -15,6 +15,7 @@
 * [**Threading**](threading.md)
 * [**Tips**](tips.md)
 * [**ViewModel and State factories**](factories.md)
+* [**Unit Testing**](testing.md)
 ---
 * [**Mavericks + Coroutines**](coroutines.md)
 * [**Mavericks + RxJava2**](rxjava2.md)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,32 @@
+## Unit Testing
+When writing unit tests for view models it is helpful to force the backing coroutines to run synchronously, as well as to have control over the state of the viewmodel.
+
+Mavericks provides support for managing this in both JUnit 4 and 5 tests via the optional `mavericks-testing` artifact.
+
+To use, apply either the test rule or test extension, configured to your needs via the appropriate properties. See the kdoc on the respective classes for the most up to date documentation on usage.
+
+By default, the rule/extension will:
+- Disable lifecycle awareness of viewmodel observers
+- Make state store operations synchronous
+- Disable debug checks on viewmodels
+- Swap TestCoroutineDispatcher for the Main coroutine dispatcher.
+
+### JUnit 5 Extension
+
+Add the `MvRxTestExtension` to your test's companion object.
+```kotlin
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val mvrxTestExtension = MvRxTestExtension()
+    }
+```
+
+### JUnit 4 Rule
+
+Add the `MvRxTestRule` rule to your test.
+
+```kotlin
+    @get:Rule
+    val mvrxRule = MvRxTestRule()
+```

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.5.1
+VERSION_NAME=2.6.0
 GROUP=com.airbnb.android
 POM_DESCRIPTION=Mavericks is an Android application framework that makes product development fast and fun.
 POM_URL=https://github.com/airbnb/mavericks

--- a/sample-compose/build.gradle
+++ b/sample-compose/build.gradle
@@ -37,6 +37,7 @@ android {
     packagingOptions {
         exclude 'META-INF/LGPL2.1'
         exclude 'META-INF/AL2.0'
+        exclude 'META-INF/LICENSE.md'
     }
 
     buildFeatures {

--- a/sample-compose/build.gradle
+++ b/sample-compose/build.gradle
@@ -37,7 +37,8 @@ android {
     packagingOptions {
         exclude 'META-INF/LGPL2.1'
         exclude 'META-INF/AL2.0'
-        exclude 'META-INF/LICENSE.md'
+        pickFirst 'META-INF/LICENSE.md'
+        pickFirst 'META-INF/LICENSE-notice.md'
     }
 
     buildFeatures {


### PR DESCRIPTION
Big thanks to @itsandreramon for contributing the two main improvements in this release!

- Pre-configure Hilt by adding a new "mvrx-hilt" artifact (#598)

See the updated Hilt documentation for guidance on how to more easily use Hilt with Mavericks https://airbnb.io/mavericks/#/dagger?id=hilt

- Add support to use Mavericks with JUnit 5 (#600)

See the new testing documentation at https://airbnb.io/mavericks/#/testing for details.

- Don't expose lifecycleAwareLazy in viewModel return type (#603)