### PR TITLE
Use passed scope as fragment if possible

### DIFF
--- a/mvrx-compose/src/main/kotlin/com/airbnb/mvrx/compose/MavericksComposeExtensions.kt
+++ b/mvrx-compose/src/main/kotlin/com/airbnb/mvrx/compose/MavericksComposeExtensions.kt
@@ -64,7 +64,7 @@ inline fun <reified VM : MavericksViewModel<S>, reified S : MavericksState> mave
     val view = LocalView.current
 
     val viewModelContext = remember(scope, activity, viewModelStoreOwner, savedStateRegistry) {
-        val parentFragment = findFragmentFromView(view)
+        val parentFragment = scope as? Fragment ?: findFragmentFromView(view)
 
         if (parentFragment != null) {
             val args = argsFactory?.invoke() ?: parentFragment.arguments?.get(Mavericks.KEY_ARG)


### PR DESCRIPTION
In `mavericksViewModel` we are trying to find a parent from a `View` and that works fine for basic use case. But the problem pops up when user wants to pass the fragment directly and it's not the view fragment (for example user is passing parent fragment to reuse view model across the tabs).

This PR fixes that. If passed `scope` is Fragment - let's just use that instead of searching for it in view tree