### PR TITLE
Mavericks Extensions argsOrNull

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksExtensions.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksExtensions.kt
@@ -247,6 +247,31 @@ fun <V : Any> args() = object : ReadOnlyProperty<Fragment, V> {
 }
 
 /**
+ * Fragment argument delegate that makes it possible to set fragment args without
+ * creating a key for each one.
+ *
+ * To create nullable arguments, define a property in your fragment like:
+ *     `private val listingId by argsOrNull<MyArgs?>()`
+ *
+ * Each fragment can only have a single argument with the key [Mavericks.KEY_ARG]
+ */
+fun <V : Any> argsOrNull() = object : ReadOnlyProperty<Fragment, V?> {
+    var value: V? = null
+    var read: Boolean = false
+
+    override fun getValue(thisRef: Fragment, property: KProperty<*>): V? {
+        if (!read) {
+            val args = thisRef.arguments
+            val argUntyped = args?.get(Mavericks.KEY_ARG)
+            @Suppress("UNCHECKED_CAST")
+            value = argUntyped as? V
+            read = true
+        }
+        return value
+    }
+}
+
+/**
  * Takes anything that is serializable and creates a Mavericks Fragment argument [Bundle].
  *
  * Set this as your Fragment's arguments and you can use the [args] property delegate in your Fragment

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksExtensions.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksExtensions.kt
@@ -225,7 +225,7 @@ inline fun <T, reified VM : MavericksViewModel<S>, reified S : MavericksState> T
  * creating a key for each one.
  *
  * To create arguments, define a property in your fragment like:
- *     `private val listingId by arg<MyArgs>()`
+ *     `private val listingId: MyArgs by args()`
  *
  * Each fragment can only have a single argument with the key [Mavericks.KEY_ARG]
  */
@@ -251,11 +251,11 @@ fun <V : Any> args() = object : ReadOnlyProperty<Fragment, V> {
  * creating a key for each one.
  *
  * To create nullable arguments, define a property in your fragment like:
- *     `private val listingId by argsOrNull<MyArgs?>()`
+ *     `private val listingId: MyArgs? by argsOrNull()`
  *
  * Each fragment can only have a single argument with the key [Mavericks.KEY_ARG]
  */
-fun <V : Any> argsOrNull() = object : ReadOnlyProperty<Fragment, V?> {
+fun <V> argsOrNull() = object : ReadOnlyProperty<Fragment, V?> {
     var value: V? = null
     var read: Boolean = false
 

--- a/mvrx/src/test/kotlin/com/airbnb/mvrx/ArgsTest.kt
+++ b/mvrx/src/test/kotlin/com/airbnb/mvrx/ArgsTest.kt
@@ -18,28 +18,58 @@ class MvRxArgsFragment : Fragment(), MavericksView {
     override fun invalidate() {}
 }
 
+class MvRxArgsOrNullFragment : Fragment(), MavericksView {
+    val args: MvrxArgsTestArgs? by argsOrNull()
+
+    override fun invalidate() {}
+}
+
 class MvRxFragmentTest : BaseTest() {
     @Test
-    fun testArgs() {
+    fun testByArgsWithArgs() {
         val (_, fragment) = createFragment<MvRxArgsFragment, TestMvRxActivity>(args = MvrxArgsTestArgs())
         Assert.assertEquals(0, fragment.args.count)
     }
 
     @Test
-    fun testSetArgs() {
+    fun testByArgsSetArgs() {
         val (_, fragment) = createFragment<MvRxArgsFragment, TestMvRxActivity>(args = MvrxArgsTestArgs(2))
         Assert.assertEquals(2, fragment.args.count)
     }
 
     @Test(expected = ClassCastException::class)
-    fun testSetWrongArgs() {
+    fun testByArgsSetWrongArgs() {
         val (_, fragment) = createFragment<MvRxArgsFragment, TestMvRxActivity>(args = MvrxArgsTestArgs2(2))
         fragment.args
     }
 
     @Test(expected = IllegalArgumentException::class)
-    fun testNoArgs() {
+    fun testByArgsWithNoArgs() {
         val (_, fragment) = createFragment<MvRxArgsFragment, TestMvRxActivity>()
+        fragment.args
+    }
+
+    @Test
+    fun testByArgsOrNullWithArgs() {
+        val (_, fragment) = createFragment<MvRxArgsOrNullFragment, TestMvRxActivity>(args = MvrxArgsTestArgs())
+        Assert.assertEquals(0, fragment.args?.count)
+    }
+
+    @Test
+    fun testByArgsOrNullSetArgs() {
+        val (_, fragment) = createFragment<MvRxArgsOrNullFragment, TestMvRxActivity>(args = MvrxArgsTestArgs(2))
+        Assert.assertEquals(2, fragment.args?.count)
+    }
+
+    @Test
+    fun testByArgsOrNullWithNoArgs() {
+        val (_, fragment) = createFragment<MvRxArgsOrNullFragment, TestMvRxActivity>()
+        Assert.assertNull(fragment.args?.count)
+    }
+
+    @Test(expected = ClassCastException::class)
+    fun testByArgsOrNullSetWrongArgs() {
+        val (_, fragment) = createFragment<MvRxArgsOrNullFragment, TestMvRxActivity>(args = MvrxArgsTestArgs2(2))
         fragment.args
     }
 }


### PR DESCRIPTION
Adding Mavericks Extensions argsOrNull which can be useful for those cases where you have an optional argument that might be sent or not.

As an example, imagine a shared screen / flow from different entry points. While this can be fixed in multiple ways in the client's code having an explicit enum that represents null / empty / none it ends up being more code which ultimately represents the same thing (although this introduces the option of nullable arguments which can also be seen as a downside)

Thoughts?