### PR TITLE
Prepare for release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Experimental `mvrx-common` module with new abstraction `MavericksRepository` that behaves exactly like `MavericksViewModel` except it doesn't have any Android dependencies and can be used in pure Kotlin modules (#635)
 - Breaking changes: `MavericksViewModelConfig.BlockExecutions` is extracted into top level class `MavericksBlockExecutions` (#635)
 - New mavericks extension `argsOrNull` to handle optional (nullable) fragment args (#639)
+- New Anvil sample in the `sample-anvil` module
 
 ## 2.7.0
 - Add mockEightViewModels and mockNineViewModels to MockBuilder (#633)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,9 @@
+Releasing
+========
+
+1. Bump the VERSION_NAME property in `gradle.properties` based on Major.Minor.Patch naming scheme
+2. Update `CHANGELOG.md` for the impending release.
+   1. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the version you set in step 1)
+3. `./gradlew clean uploadArchives --no-daemon --no-parallel`
+4. Visit [Sonatype Nexus](https://oss.sonatype.org/) and promote the artifact.
+5. Open PR with on Github, merge, and publish release through Github UI.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,7 +3,7 @@ Releasing
 
 1. Bump the VERSION_NAME property in `gradle.properties` based on Major.Minor.Patch naming scheme
 2. Update `CHANGELOG.md` for the impending release.
-   1. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the version you set in step 1)
-3. `./gradlew clean uploadArchives --no-daemon --no-parallel`
-4. Visit [Sonatype Nexus](https://oss.sonatype.org/) and promote the artifact.
-5. Open PR with on Github, merge, and publish release through Github UI.
+3. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the version you set in step 1)
+4. Add your sonatype login information under gradle properties mavenCentralUsername and mavenCentralPassword in your local user gradle.properties file
+5. `./gradlew publish` to build the artifacts and publish them to maven
+7. Open PR on Github, merge, and publish release through Github UI.

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,14 @@ POM_LICENSE_DIST=repo
 POM_DEVELOPER_ID=airbnb
 POM_DEVELOPER_NAME=Airbnb
 POM_INCEPTION_YEAR=2018
+
+# Publishing configuration for vanniktech/gradle-maven-publish-plugin
+SONATYPE_HOST=DEFAULT
+RELEASE_SIGNING_ENABLED=true
+SONATYPE_AUTOMATIC_RELEASE=true
+
 android.useAndroidX=true
+
 # With the default memory size Gradle gets out of memory issues when building, so we have to increase it
 # Dokka fails without a larger metaspace https://github.com/Kotlin/dokka/issues/1405
-org.gradle.jvmargs=-Xms128m -Xmx2048m -XX:+CMSClassUnloadingEnabled -XX:MaxMetaspaceSize=1g
+org.gradle.jvmargs=-Xms128m -Xmx4096m -XX:+CMSClassUnloadingEnabled -XX:MaxMetaspaceSize=2g

--- a/versions.properties
+++ b/versions.properties
@@ -12,6 +12,8 @@ version.rxjava2.rxjava=2.2.21
 version.rxjava2.rxandroid=2.1.1
 
 version.robolectric=4.8.1
+##      # available=4.8.2
+##      # available=4.9-alpha-1
 
 version.retrofit2=2.9.0
 
@@ -27,7 +29,8 @@ version.org.jetbrains.dokka..javadoc-plugin=1.4.32
 ## unused
 version.org.jetbrains.dokka..gfm-plugin=1.4.32
 
-version.org.jetbrains.dokka..dokka-gradle-plugin=1.7.10
+# 1.7.10 runs into a failure https://github.com/Kotlin/dokka/issues/2452
+version.org.jetbrains.dokka..dokka-gradle-plugin=1.6.10
 
 ## unused
 version.org.jetbrains.dokka..dokka-base=1.4.32
@@ -36,30 +39,45 @@ version.org.jetbrains.dokka..dokka-base=1.4.32
 version.org.jacoco..org.jacoco.ant=0.8.7
 
 version.moshi=1.13.0
+### available=1.14.0
 
 version.mockk=1.12.5
+### available=1.12.6
+### available=1.12.7
+### available=1.12.8
+### available=1.13.1
+### available=1.13.2
 
 version.mockito=4.6.1
+##  # available=4.7.0
+##  # available=4.8.0
 
 version.kotlinx.coroutines=1.6.4
 
 version.kotlin=1.7.10
 ## # available=1.7.20-Beta
+## # available=1.7.20-RC
+## # available=1.7.20
 
  version.koin=3.2.0
+### available=3.2.1
+### available=3.2.2
 
 version.junit.jupiter=5.8.2
 ##        # available=5.9.0-M1
 ##        # available=5.9.0-RC1
 ##        # available=5.9.0
+##        # available=5.9.1
 
 version.junit.junit=4.13.2
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.21.0
+##                                         # available=1.22.0-RC1
 
 version.google.dagger=2.43.2
+##        # available=2.44
 
-version.com.vanniktech..gradle-maven-publish-plugin=0.21.0
+version.com.vanniktech..gradle-maven-publish-plugin=0.22.0
 
 version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
@@ -105,31 +123,42 @@ version.androidx.test.core=1.4.0
 ##             # available=1.4.1-alpha06
 ##             # available=1.4.1-alpha07
 ##             # available=1.5.0-alpha01
+##             # available=1.5.0-alpha02
 
 version.androidx.room=2.4.3
 ##        # available=2.5.0-alpha01
 ##        # available=2.5.0-alpha02
+##        # available=2.5.0-alpha03
 
 version.androidx.recyclerview=1.2.1
 ##                # available=1.3.0-alpha01
 ##                # available=1.3.0-alpha02
 ##                # available=1.3.0-beta01
 ##                # available=1.3.0-beta02
+##                # available=1.3.0-rc01
 
 version.androidx.navigation-compose=2.5.1
+##                      # available=2.5.2
+##                      # available=2.6.0-alpha01
 
 version.androidx.navigation=2.5.1
+##              # available=2.5.2
+##              # available=2.6.0-alpha01
 
 version.androidx.multidex=2.0.1
 
 version.androidx.lifecycle-viewmodel-compose=2.5.1
 ##                               # available=2.6.0-alpha01
+##                               # available=2.6.0-alpha02
 
 version.androidx.lifecycle=2.5.1
 ##             # available=2.6.0-alpha01
+##             # available=2.6.0-alpha02
 
 version.androidx.fragment=1.5.2
+##            # available=1.5.3
 ##            # available=1.6.0-alpha01
+##            # available=1.6.0-alpha02
 
 ## unused
 version.androidx.databinding=7.2.2
@@ -141,6 +170,8 @@ version.androidx.core=1.8.0
 ##        # available=1.9.0-alpha04
 ##        # available=1.9.0-alpha05
 ##        # available=1.9.0-beta01
+##        # available=1.9.0-rc01
+##        # available=1.9.0
 
 version.androidx.coordinatorlayout=1.2.0
 
@@ -148,21 +179,31 @@ version.androidx.constraintlayout=2.1.4
 ##                    # available=2.2.0-alpha01
 ##                    # available=2.2.0-alpha02
 ##                    # available=2.2.0-alpha03
+##                    # available=2.2.0-alpha04
 
 version.androidx.compose.ui=1.2.1
 ##              # available=1.3.0-alpha01
 ##              # available=1.3.0-alpha02
 ##              # available=1.3.0-alpha03
+##              # available=1.3.0-beta01
+##              # available=1.3.0-beta02
+##              # available=1.3.0-beta03
 
 version.androidx.compose.material=1.2.1
 ##                    # available=1.3.0-alpha01
 ##                    # available=1.3.0-alpha02
 ##                    # available=1.3.0-alpha03
+##                    # available=1.3.0-beta01
+##                    # available=1.3.0-beta02
+##                    # available=1.3.0-beta03
 
 version.androidx.compose.foundation=1.2.1
 ##                      # available=1.3.0-alpha01
 ##                      # available=1.3.0-alpha02
 ##                      # available=1.3.0-alpha03
+##                      # available=1.3.0-beta01
+##                      # available=1.3.0-beta02
+##                      # available=1.3.0-beta03
 
 ## unused
 version.androidx.compose.compiler=1.3.0
@@ -170,19 +211,25 @@ version.androidx.compose.compiler=1.3.0
 version.androidx.cardview=1.0.0
 
 version.androidx.appcompat=1.5.0
+##             # available=1.5.1
 ##             # available=1.6.0-alpha01
 ##             # available=1.6.0-alpha03
 ##             # available=1.6.0-alpha04
 ##             # available=1.6.0-alpha05
 ##             # available=1.6.0-beta01
+##             # available=1.6.0-rc01
 
 version.androidx.activity=1.5.1
 ##            # available=1.6.0-alpha01
 ##            # available=1.6.0-alpha03
 ##            # available=1.6.0-alpha05
 ##            # available=1.6.0-beta01
+##            # available=1.6.0-rc01
+##            # available=1.6.0-rc02
+##            # available=1.6.0
 
 plugin.io.gitlab.arturbosch.detekt=1.21.0
+##                     # available=1.22.0-RC1
 
 version.anvil=2.4.2
 
@@ -201,6 +248,8 @@ plugin.android=7.2.2
 ## # available=7.3.0-beta03
 ## # available=7.3.0-beta04
 ## # available=7.3.0-beta05
+## # available=7.3.0-rc01
+## # available=7.3.0
 ## # available=7.4.0-alpha01
 ## # available=7.4.0-alpha02
 ## # available=7.4.0-alpha03
@@ -210,3 +259,7 @@ plugin.android=7.2.2
 ## # available=7.4.0-alpha07
 ## # available=7.4.0-alpha08
 ## # available=7.4.0-alpha09
+## # available=7.4.0-alpha10
+## # available=7.4.0-beta01
+## # available=8.0.0-alpha01
+## # available=8.0.0-alpha02


### PR DESCRIPTION
## 3.0.0
- Experimental `mvrx-common` module with new abstraction `MavericksRepository` that behaves exactly like `MavericksViewModel` except it doesn't have any Android dependencies and can be used in pure Kotlin modules (#635)
- Breaking changes: `MavericksViewModelConfig.BlockExecutions` is extracted into top level class `MavericksBlockExecutions` (#635)
- New mavericks extension `argsOrNull` to handle optional (nullable) fragment args (#639)
- New Anvil sample in the `sample-anvil` module
- Updating vanniktech/gradle-maven-publish-plugin, allowing publishing with just `./gradlew publish`; this allows daemon/parallel usage for faster runtime as well as automatically handling closing of the remote sonatype repository and publishing of the artifact.