### PR TITLE
Print fqn of classes in error messages

### DIFF
--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksExtensions.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksExtensions.kt
@@ -74,7 +74,7 @@ inline fun <T, reified VM : MavericksViewModel<S>, reified S : MavericksState> T
         if (parentFragment == null) {
             // Using ViewModelDoesNotExistException so mocking framework can intercept and mock the viewmodel in this case.
             throw ViewModelDoesNotExistException(
-                "There is no parent fragment for ${this::class.java.simpleName} so view model ${viewModelClass.simpleName} could not be found."
+                "There is no parent fragment for ${this::class.java.name} so view model ${viewModelClass.java.name} could not be found."
             )
         }
         var parent: Fragment? = parentFragment
@@ -136,7 +136,7 @@ inline fun <T, reified VM : MavericksViewModel<S>, reified S : MavericksState> T
 
         @Suppress("DEPRECATION")
         val targetFragment =
-            requireNotNull(targetFragment) { "There is no target fragment for ${this::class.java.simpleName}!" }
+            requireNotNull(targetFragment) { "There is no target fragment for ${this::class.java.name}!" }
 
         MavericksViewModelProvider.get(
             viewModelClass = viewModelClass.java,

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksFactory.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksFactory.kt
@@ -55,12 +55,12 @@ private fun <VM : MavericksViewModel<S>, S : MavericksState> createViewModel(
     }
     val viewModel = requireNotNull(factoryViewModel ?: createDefaultViewModel(viewModelClass, initialState)) {
         if (viewModelClass.constructors.firstOrNull()?.parameterTypes?.size?.let { it > 1 } == true) {
-            "${viewModelClass.simpleName} takes dependencies other than initialState. " +
-                "It must have companion object implementing ${MavericksViewModelFactory::class.java.simpleName} " +
+            "${viewModelClass.name} takes dependencies other than initialState. " +
+                "It must have companion object implementing ${MavericksViewModelFactory::class.java.name} " +
                 "with a create method returning a non-null ViewModel."
         } else {
-            "${viewModelClass::class.java.simpleName} must have primary constructor with a " +
-                "single non-optional parameter that takes initial state of ${stateClass.simpleName}."
+            "${viewModelClass::class.java.name} must have primary constructor with a " +
+                "single non-optional parameter that takes initial state of ${stateClass.name}."
         }
     }
     return MavericksViewModelWrapper(viewModel)

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksStateFactory.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksStateFactory.kt
@@ -95,10 +95,10 @@ internal fun <VM : MavericksViewModel<S>, S : MavericksState> createStateFromCon
         }
         // Throw this exception if we don't know which method to use to create the initial state.
         ?: throw IllegalStateException(
-            "Attempt to create the Mavericks state class ${stateClass.simpleName} has failed. One of the following must be true:" +
+            "Attempt to create the Mavericks state class ${stateClass.name} has failed. One of the following must be true:" +
                 "\n 1) The state class has default values for every constructor property." +
                 "\n 2) The state class has a secondary constructor for ${
-                args?.javaClass?.simpleName
+                args?.javaClass?.name
                     ?: "a fragment argument"
                 }." +
                 "\n 3) ${viewModelClass.simpleName} must have a companion object implementing MavericksViewModelFactory with an initialState " +

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModel.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/MavericksViewModel.kt
@@ -329,7 +329,7 @@ abstract class MavericksViewModel<S : MavericksState>(
         }
     }
 
-    override fun toString(): String = "${this::class.java.simpleName} $state"
+    override fun toString(): String = "${this::class.java.name} $state"
 
     private inner class Repository : MavericksRepository<S>(
         MavericksRepositoryConfig(

--- a/mvrx/src/main/kotlin/com/airbnb/mvrx/PersistState.kt
+++ b/mvrx/src/main/kotlin/com/airbnb/mvrx/PersistState.kt
@@ -69,7 +69,7 @@ private fun <T : MavericksState> Class<out T>.getComponentNFunction(componentInd
         declaredMethods.firstOrNull { it.name.startsWith("$functionName\$") }
     }
         ?.also { it.isAccessible = true }
-        ?: error("Unable to find function $functionName in ${this@getComponentNFunction::class.simpleName}")
+        ?: error("Unable to find function $functionName in ${this@getComponentNFunction::class.java.name}")
 }
 
 private fun assertCollectionPersistability(value: Any?) {
@@ -88,7 +88,7 @@ private fun assertCollectionPersistability(value: Any?) {
 }
 
 private fun assertPersistable(item: Any) {
-    if (item !is Serializable && item !is Parcelable) error("Cannot parcel ${item::class.java.simpleName}")
+    if (item !is Serializable && item !is Parcelable) error("Cannot parcel ${item::class.java.name}")
 }
 
 private fun <T : Any?> Bundle.putAny(key: String?, value: T): Bundle {


### PR DESCRIPTION
Print fqn of classes in error messages as with obfuscation the simple name might just be `a` or any other very generic name that might be shared by many other classes.

e.g.

```
Caused by: java.lang.IllegalArgumentException: a takes dependencies other than initialState. It must have companion object implementing MavericksViewModelFactory with a create method returning a non-null ViewModel.
```

This makes it very had to find the affected class via the mapping file.

